### PR TITLE
Use classifiers to specify the license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,4 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name="yapo",
     packages=find_packages(),
+    classifiers=[
+        'License :: OSI Approved :: MIT License',
+    ],
 )


### PR DESCRIPTION
Classifiers are a standard way of specifying a license, and make it easy
for automated tools to properly detect the license of the package.

The "license" field should only be used if the license has no
corresponding Trove classifier.